### PR TITLE
PSTN to client fix

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "Twilio Mobile Quickstart",
   "description": "A simple Python server to distribute capability tokens and route calls for your mobile app",
-  "repository": "https://github.com/vassjozsef/mobile-quickstart",
+  "repository": "https://github.com/gtrnocswift/mobile-quickstart",
   "logo": "https://static1.twilio.com/packages/company/img/logos_icon_round.png",
   "keywords": [
     "twilio",
@@ -23,6 +23,10 @@
     },
     "CALLER_ID": {
       "description": "Phone number verified with your Twilio Account",
+      "required": true
+    },
+    "PSTN_ENDPOINT": {
+      "description": "Name of client to connect to from PSTN",
       "required": true
     }
   }

--- a/server.py
+++ b/server.py
@@ -47,7 +47,8 @@ def call():
   from_value = request.values.get('From')
   to = request.values.get('To')
   if not (from_value and to):
-    return str(resp.say("Invalid request"))
+    resp.say("Invalid request")
+    return str(resp)
   from_client = from_value.startswith('client')
   caller_id = os.environ.get("CALLER_ID", CALLER_ID)
   if not from_client:

--- a/server.py
+++ b/server.py
@@ -15,7 +15,7 @@ CLIENT = 'jenny'
 
 app = Flask(__name__)
 
-@app.route('/token')
+@app.route('/token', strict_slashes=False)
 def token():
   account_sid = os.environ.get("ACCOUNT_SID", ACCOUNT_SID)
   auth_token = os.environ.get("AUTH_TOKEN", AUTH_TOKEN)
@@ -35,7 +35,7 @@ def token():
   # This returns a token to use with Twilio based on the account and capabilities defined above
   return capability.generate()
 
-@app.route('/call', methods=['GET', 'POST'])
+@app.route('/call', methods=['GET', 'POST'], strict_slashes=False)
 def call():
   """ This method routes calls from/to client                  """
   """ Rules: 1. From can be either client:name or PSTN number  """
@@ -60,7 +60,7 @@ def call():
     resp.dial(to, callerId=caller_id)
   return str(resp)
 
-@app.route('/', methods=['GET', 'POST'])
+@app.route('/', methods=['GET', 'POST'], strict_slashes=False)
 def welcome():
   resp = twilio.twiml.Response()
   resp.say("Welcome to Twilio")

--- a/server.py
+++ b/server.py
@@ -11,9 +11,10 @@ AUTH_TOKEN = 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
 APP_SID = 'APZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ'
 
 CALLER_ID = '+12345678901'
-CLIENT = 'jenny'
+PSTN_ENDPOINT = 'jenny'
 
 app = Flask(__name__)
+pstn_endpoint = os.environ.get("PSTN_ENDPOINT", PSTN_ENDPOINT)
 
 @app.route('/token', strict_slashes=False)
 def token():
@@ -41,7 +42,7 @@ def call():
   """ Rules: 1. From can be either client:name or PSTN number  """
   """        2. To value specifies target. When call is coming """
   """           from PSTN, To value is ignored and call is     """
-  """           routed to client named CLIENT                  """
+  """           routed to client from pstn_endpoint            """
   resp = twilio.twiml.Response()
   from_value = request.values.get('From')
   to = request.values.get('To')
@@ -51,7 +52,7 @@ def call():
   caller_id = os.environ.get("CALLER_ID", CALLER_ID)
   if not from_client:
     # PSTN -> client
-    resp.dial(callerId=from_value).client(CLIENT)
+    resp.dial(callerId=from_value).client(pstn_endpoint)
   elif to.startswith("client:"):
     # client -> client
     resp.dial(callerId=from_value).client(to[7:])


### PR DESCRIPTION
PSTN to client wasn’t working because twilio kept adding a trailing
slash to the number voice registration