### PR TITLE
Fixing TwiML response for invalid input in /call handler.

### DIFF
--- a/server.py
+++ b/server.py
@@ -46,7 +46,8 @@ def call():
   from_value = request.values.get('From')
   to = request.values.get('To')
   if not (from_value and to):
-    return str(resp.say("Invalid request"))
+    resp.say("Invalid request")
+    return str(resp)
   from_client = from_value.startswith('client')
   caller_id = os.environ.get("CALLER_ID", CALLER_ID)
   if not from_client:


### PR DESCRIPTION
Right now invalid input to /call returns:

```
<Say>Invalid request</Say>
```

instead of:

```
<Response><Say>Invalid request</Say></Response>
```

The Python TwiML classes do not support chaining method calls as expected.